### PR TITLE
Update dependencies to make Mingus buildable again

### DIFF
--- a/mingus/stable-requirements.txt
+++ b/mingus/stable-requirements.txt
@@ -22,7 +22,7 @@ django-memcache-status==1.0.1
 -e git://github.com/montylounge/django-disqus.git@35a022f28c50b9f7cdfcdd5deb4ae6f9150f4358#egg=django_disqus-0.1-py2.5-dev
 -e git://github.com/zerok/django-flatblocks.git@77c310727d5ec5a0f69cdeda2b71bea8613503f0#egg=django_flatblocks-0.3.3-py2.5-dev
 -e git://github.com/sunlightlabs/django-honeypot.git@76f57f487f68825fb302269516bb2b3284b81801#egg=django_honeypot-0.2.1-py2.5-dev
--e svn+http://django-navbar.googlecode.com/svn/trunk@20#egg=django_navbar-0.1.1rc1-py2.5-dev_r20
+-e svn+http://django-navbar.googlecode.com/svn/trunk@28#egg=django_navbar-0.3.0-final-py2.5-dev_r28
 -e git://github.com/brosner/django-oembed.git@0b09321a6042c490534e5940083136f712da57b0#egg=django_oembed-0.1.0-py2.5-dev
 -e git://github.com/montylounge/django-proxy.git@37f5e24c4426aeec6fc20473d1213fafb6e5c489#egg=django_proxy-0.1.0-py2.5-dev
 -e git://github.com/montylounge/django-quoteme.git@d067a0da1756867250af9d836b8e0d47ff6c7c44#egg=django_quoteme-0.2-py2.5-dev
@@ -35,7 +35,7 @@ django-memcache-status==1.0.1
 -e git://github.com/pydanny/django-wysiwyg.git@b280e1b75326363dfe746d8c36425cfbed53b4ec#egg=django_wysiwyg-0.1.0-py2.5-dev
 -e git://github.com/montylounge/django-google-analytics.git@6b7aa6dba851dd59dca0a20bc7eefe70754384e4#egg=google_analytics-0.1-py2.5-dev
 -e hg+https://python-twitter.googlecode.com/hg/@7e5cb2db67352ac1fd7b40a3ec54fdef352f802f#egg=python_twitter-0.7_devel-py2.5-default
--e hg+https://sorl-thumbnail.googlecode.com/hg/@caf69b5206329d89282b4b8246a72e5aa77cb578#egg=sorl_thumbnail-tip
+-e git://github.com/sorl/sorl-thumbnail.git@e075773947460622232bc2a66a41fd721254cc99#egg=sorl_thumbnail-tip
 -e svn+http://django-template-utils.googlecode.com/svn/trunk@109#egg=template_utils-0.4p2-py2.5-dev_r109
 -e git://github.com/montylounge/django_cropper.git@194e3c94b0abcb5ec2a9788ff1fe474779b3f67d#egg=django-cropper-0.1.5a-py2.5-dev
 -e git://github.com/kylef/django-request.git@84cfef56f6eea281a9c382859fb29ef570c7295d#egg=django_request-0.21-py2.5-dev


### PR DESCRIPTION
Updated dependencies to make it build again:
- Changed sorl-thumbnail repository location from the removed Google Code Mercurial repository to the new git repository. See: https://code.google.com/p/support/issues/detail?id=4703
- Updated django-navbar from r20 to 28 (0.3.0-final) because r28 removes trailing slashes which prevent the build on Windows. See: https://code.google.com/p/django-navbar/source/diff?spec=svn28&amp;r=28&amp;format=side&amp;path=/trunk/MANIFEST.in
