### PR TITLE
remove broken blog links from README

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -17,17 +17,14 @@ To see it live in action, view:
 
 "http://blog.montylounge.com":http://blog.montylounge.com
 "http://ericholscher.com/":http://ericholscher.com/
-"http://apluggedinlife.com/fr/":http://apluggedinlife.com/fr/
 "http://blog.roseman.org.uk/":http://blog.roseman.org.uk/
 "http://codysoyland.com/":http://codysoyland.com/
 "http://www.ofbrooklyn.com/":http://www.ofbrooklyn.com/
 "http://hotsyk.com/":http://hotsyk.com/
 "http://stfnkhlr.de/":http://stfnkhlr.de/
 "http://mathematism.com/":http://mathematism.com/
-"http://baratrion.org/":http://baratrion.org/
 "http://libby.tuzig.com/":http://libby.tuzig.com/
 "http://oswco.com/":http://oswco.com/
-"http://serotoninstorm.com/blog/":http://serotoninstorm.com/blog/
 
 
 h2. Getting Started


### PR DESCRIPTION
There were some broken links in the examples. Some are parked and some do not connect.
